### PR TITLE
Make the use of bitflags future-proof

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ edition = "2018"
 travis-ci = { repository = "mozilla/audio-mixer" }
 
 [dependencies]
-bitflags = "1.2"
+bitflags = "1.3"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -64,18 +64,11 @@ bitflags! {
 // Avoid printing the following types in debugging context {:?} by declaring them in impl
 // rather than bitflags! {} scope.
 impl ChannelMap {
-    pub const FRONT_2: Self = Self {
-        bits: Self::FRONT_LEFT.bits() | Self::FRONT_RIGHT.bits(),
-    };
-    pub const BACK_2: Self = Self {
-        bits: Self::BACK_LEFT.bits() | Self::BACK_RIGHT.bits(),
-    };
-    pub const FRONT_2_OF_CENTER: Self = Self {
-        bits: Self::FRONT_LEFT_OF_CENTER.bits() | Self::FRONT_RIGHT_OF_CENTER.bits(),
-    };
-    pub const SIDE_2: Self = Self {
-        bits: Self::SIDE_LEFT.bits() | Self::SIDE_RIGHT.bits(),
-    };
+    pub const FRONT_2: Self = Self::union(Self::FRONT_LEFT, Self::FRONT_RIGHT);
+    pub const BACK_2: Self = Self::union(Self::BACK_LEFT, Self::BACK_RIGHT);
+    pub const FRONT_2_OF_CENTER: Self =
+        Self::union(Self::FRONT_LEFT_OF_CENTER, Self::FRONT_RIGHT_OF_CENTER);
+    pub const SIDE_2: Self = Self::union(Self::SIDE_LEFT, Self::SIDE_RIGHT);
 }
 
 impl From<Channel> for ChannelMap {


### PR DESCRIPTION
bitflags types are opaque in bitflags 2, so defining constants using Type { bits: ... } won't work there.

Ideally, we would be able to do something like:
```
pub const AB: Type = Type::A | Type::B;
```

but `|` is not const when using the `BitOr` trait. So we rely on `Type::union` instead.